### PR TITLE
Translations update from Ayana Weblate

### DIFF
--- a/th/general.json
+++ b/th/general.json
@@ -13,6 +13,7 @@
     "SETTING_AFK_ACTIVE_DESCRIPTION": "เปิด/ปิดการใช้งานข้อความ AFK ทั่วทั้งเซิร์ฟเวอร์",
     "SETTING_AUTOROLE_ACTIVE_DESCRIPTION": "ควรกำหนดตำแหน่งให้กับสมาชิกที่เข้าร่วม",
     "SETTING_AUTOROLE_ROLE_DESCRIPTION": "ตำแหน่งที่จะให้ในการเข้าร่วม",
+    "SETTING_CTA_ACTIVE_DESCRIPTION": "ควรอนุญาตข้อความ CTA มั้ย",
     "SETTING_FAREWELL_ACTIVE_DESCRIPTION": "ต้องการให้แจ้งสมาชิกออกจากเซิร์ฟเวอร์หรือไม่",
     "SETTING_FAREWELL_CHANNEL_DESCRIPTION": "ช่องสำหรับแจ้งสมาชิกออกจากเซิร์ฟเวอร์",
     "SETTING_FAREWELL_DM_DESCRIPTION": "ส่งข้อความบอกลาทางDMของสมาชิกแทน",

--- a/th/music.json
+++ b/th/music.json
@@ -52,7 +52,7 @@
     "MUSIC_JOIN_MESSAGE": ":white_check_mark: เข้าห้อง :speaker:`{voice}`.",
     "MUSIC_JUMPED": "ข้ามไปที่เพลง `{track}` ตำแหน่งที่ **{position}**",
     "MUSIC_LEAVE_MESSAGE": ":no_entry: ออกจากห้องพูดคุยและเลิกยึดคำสั้งจากห้องที่เคยใช้",
-    "MUSIC_MISSING_PERMISSION_TO_JOIN": "เกิดข้อผิดพลาดขณะดำเนินการคำสั่งนี้: `การอนุญาตถูกปฏิเสธในการเข้าร่วมช่องเสียงนี้`",
+    "MUSIC_MISSING_PERMISSION_TO_JOIN": "สิทธิ์การเข้าร่วมช่องเสียถูกปฏิเสธ",
     "MUSIC_NOT_PLAYING": "ไม่มีอะไรเล่นอยู่",
     "MUSIC_NO_MATCHES": "ไม่พบอะไรที่ไกล้เคียงกัน",
     "MUSIC_NO_TRACK_AT_POSITION": "ไม่มีเพลงในตำแหน่งนั้น",

--- a/th/words.json
+++ b/th/words.json
@@ -16,6 +16,7 @@
     "WORD_DEVELOPERS": "ผู้พัฒนา",
     "WORD_DISABLED_EVENTS": "ปิดการใช้งาน อีเว้นท์",
     "WORD_ERROR": "ข้อผิดพลาด",
+    "WORD_EXAMPLE": "ตัวอย่าง",
     "WORD_GROUPS": "กลุ่ม",
     "WORD_HEADS": "หัว",
     "WORD_HIDDEN": "ซ่อน",


### PR DESCRIPTION
Translations update from [Ayana Weblate](https://translate.ayana.io) for [Ayana/_meta (Language Display)](https://translate.ayana.io/projects/ayana/_meta/).


It also includes following components:

* [Ayana/Images](https://translate.ayana.io/projects/ayana/images/)

* [Ayana/Events](https://translate.ayana.io/projects/ayana/events/)

* [Ayana/Commands](https://translate.ayana.io/projects/ayana/commands/)

* [Ayana/Responses](https://translate.ayana.io/projects/ayana/responses/)

* [Ayana/General](https://translate.ayana.io/projects/ayana/general/)

* [Ayana/Waifuquest](https://translate.ayana.io/projects/ayana/waifuquest/)

* [Ayana/Words](https://translate.ayana.io/projects/ayana/words/)

* [Ayana/Bentocord](https://translate.ayana.io/projects/ayana/bentocord/)

* [Ayana/Music](https://translate.ayana.io/projects/ayana/music/)



Current translation status:

![Weblate translation status](https://translate.ayana.io/widgets/ayana/-/_meta/horizontal-auto.svg)